### PR TITLE
Switch to frequency

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@ LOG_LEVEL=warn
 MQTT_HOST=solar-assistant.local
 MQTT_PORT=1883
 MQTT_TOPIC=solar_assistant/inverter_1/grid_frequency/state
-LOW_VOLTAGE_THRESHOLD=58
+LOW_MQTT_THRESHOLD=58
 RED_LED_PIN=21
 GREEN_LED_PIN=20

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 LOG_LEVEL=warn
 MQTT_HOST=solar-assistant.local
 MQTT_PORT=1883
-MQTT_TOPIC=solar_assistant/inverter_1/grid_voltage/state
-LOW_VOLTAGE_THRESHOLD=216
+MQTT_TOPIC=solar_assistant/inverter_1/grid_frequency/state
+LOW_VOLTAGE_THRESHOLD=58
 RED_LED_PIN=21
 GREEN_LED_PIN=20

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Is Grid Available
-This application reads the inverter grid value from solar assistant mqtt. If the grid voltage is correct it turns on a green LED. If the grid voltage is below a defined threshold it runs on a red LED. It was built to be run on a Raspberry Pi Zero W running Raspberry Pi OS Bullseye.
+This application reads the inverter frequency value from solar assistant mqtt. If the grid frequency is correct it turns on a green LED. If the grid frequency is below a defined threshold it turns on a red LED. It was built to be run on a Raspberry Pi Zero W running Raspberry Pi OS Bullseye.
 
 # Install
 ```

--- a/is_grid_available.rb
+++ b/is_grid_available.rb
@@ -29,12 +29,12 @@ client = MQTT::Client.connect(
 )
 
 client.subscribe(env('MQTT_TOPIC'))
-_mqtt_topic, grid_voltage = client.get
+_mqtt_topic, mqtt_message = client.get
 client.disconnect
 
-@logger.info("Grid voltage: #{grid_voltage}")
+@logger.info("MQTT Message: #{mqtt_message}")
 
-if grid_voltage.to_i > env('LOW_VOLTAGE_THRESHOLD').to_i
+if mqtt_message.to_i > env('LOW_MQTT_THRESHOLD').to_i
   @logger.info('Grid appears to be available. Turning on green light.')
   red_led.set_mode(OUT)
   red_led.set_value(LOW)


### PR DESCRIPTION
Switch from reading voltage to reading frequency.

This is a quick fix for an issue with high voltage readings. When the grid voltage exceeds a value configured in the inverter, the inverter will disconnect the grid. However, this script as designed only compares to a low voltage value, which means it doesn't change the LED color. It was discovered will investigating the problem that the grid frequency drops to 0 when the grid is disconnected. The quickest fix was to just change the MQTT topic and threshold; variable names were also changed to improve legibility. This is a quick fix and, while it works, I'm not necessarily satisfied with the final solution.